### PR TITLE
Halmos tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "lib/multicaller"]
 	path = lib/multicaller
 	url = https://github.com/vectorized/multicaller
+[submodule "lib/halmos-cheatcodes"]
+	path = lib/halmos-cheatcodes
+	url = https://github.com/a16z/halmos-cheatcodes

--- a/contracts/modules/SuperMinterV1_1.sol
+++ b/contracts/modules/SuperMinterV1_1.sol
@@ -1121,24 +1121,31 @@ contract SuperMinterV1_1 is ISuperMinterV1_1, EIP712 {
             // The artist will receive the remaining after all BPS fees are deducted from sub total.
             // The minter will have to pay the sub total plus any flat fees.
             f.subTotal = unitPrice * uint256(quantity);
+            assert(quantity == 0 || uint(f.subTotal) / uint(quantity) == uint(unitPrice));
             // Sum the total flat fees for mints, and the transaction flat fee.
             f.platformTxFlatFee = c.perTxFlat;
             f.platformMintFlatFee = c.perMintFlat * uint256(quantity);
+            assert(quantity == 0 || uint(f.platformMintFlatFee) / uint(quantity) == uint(c.perMintFlat));
             f.platformFlatFee = f.platformMintFlatFee + f.platformTxFlatFee;
+            assert(uint(f.platformFlatFee) >= uint(f.platformMintFlatFee));
             // BPS fees are to be deducted from the sub total.
             f.platformMintBPSFee = LibOps.rawMulDiv(f.subTotal, c.perMintBPS, BPS_DENOMINATOR);
             // The platform fee includes BPS fees deducted from sub total,
             // and flat fees added to sub total.
             f.platformFee = f.platformMintBPSFee + f.platformFlatFee;
+            assert(uint(f.platformFee) >= uint(f.platformMintBPSFee));
             // Affiliate fee is to be deducted from the sub total.
             // Will be conditionally set to zero during mint if not affiliated.
             f.affiliateFee = LibOps.rawMulDiv(f.subTotal, d.affiliateFeeBPS, BPS_DENOMINATOR);
             // Calculate the incentives. These may be redirected away from the `platformFee`.
             f.affiliateIncentive = c.affiliateIncentive * uint256(quantity);
             f.cheapMintIncentive = c.cheapMintIncentive * uint256(quantity);
+            assert(quantity == 0 || uint(f.affiliateIncentive) / uint(quantity) == uint(c.affiliateIncentive));
+            assert(quantity == 0 || uint(f.cheapMintIncentive) / uint(quantity) == uint(c.cheapMintIncentive));
             f.cheapMintIncentiveThreshold = c.cheapMintIncentiveThreshold;
             // The total is the final value which the minter has to pay. It includes all fees.
             f.total = f.subTotal + f.platformFlatFee;
+            assert(uint(f.total) >= uint(f.subTotal));
         }
     }
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,4 +9,6 @@ solc_version = '0.8.19'
 
 gas_limit = 100_000_000 # ETH is 30M, but we use a higher value.
 
+extra_output = ["storageLayout", "metadata"] # for halmos tests
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/tests/modules/SuperMinterV1_1.symbolic.t.sol
+++ b/tests/modules/SuperMinterV1_1.symbolic.t.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.8.16;
 
 import {SuperMinterV1_1} from "@modules/SuperMinterV1_1.sol";
+import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 
-contract SuperMinterV1_1SymTest is SuperMinterV1_1 {
+contract SuperMinterV1_1SymTest is SuperMinterV1_1, SymTest {
 
     /// @custom:halmos --no-test-constructor --symbolic-storage
     function check_totalPriceAndFees(
@@ -13,6 +14,25 @@ contract SuperMinterV1_1SymTest is SuperMinterV1_1 {
     ) public {
         MintData storage d = _getMintData(mintId);
         _totalPriceAndFees(tier, d, quantity, signedPrice);
+    }
+
+    /// @custom:halmos --no-test-constructor --symbolic-storage
+    function check_computeAndAccrueFees(
+        uint256 mintId,
+        MintTo calldata p,
+        TotalPriceAndFees memory f
+    ) public payable {
+        MintData storage d = _getMintData(mintId);
+        MintedLogData memory l = _computeAndAccrueFees(p, d, f);
+        assert(l.finalArtistFee + l.finalPlatformFee + l.finalAffiliateFee == f.total);
+    }
+
+    function _isAffiliatedWithProof(
+        MintData storage,
+        address,
+        bytes32[] calldata
+    ) internal pure override returns (bool) {
+        return svm.createBool("_isAffiliatedWithProof");
     }
 
 }

--- a/tests/modules/SuperMinterV1_1.symbolic.t.sol
+++ b/tests/modules/SuperMinterV1_1.symbolic.t.sol
@@ -5,18 +5,18 @@ import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 
 contract SuperMinterV1_1SymTest is SuperMinterV1_1, SymTest {
 
-    /// @custom:halmos --no-test-constructor --symbolic-storage
+    /// @custom:halmos --no-test-constructor --symbolic-storage --solver-timeout-assertion 0
     function check_totalPriceAndFees(
         uint8 tier,
         uint256 mintId,
         uint32 quantity,
         uint96 signedPrice
-    ) public {
+    ) public view {
         MintData storage d = _getMintData(mintId);
         _totalPriceAndFees(tier, d, quantity, signedPrice);
     }
 
-    /// @custom:halmos --no-test-constructor --symbolic-storage
+    /// @custom:halmos --no-test-constructor --symbolic-storage --solver-timeout-assertion 0
     function check_computeAndAccrueFees(
         uint256 mintId,
         MintTo calldata p,

--- a/tests/modules/SuperMinterV1_1.symbolic.t.sol
+++ b/tests/modules/SuperMinterV1_1.symbolic.t.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.16;
+
+import {SuperMinterV1_1} from "@modules/SuperMinterV1_1.sol";
+
+contract SuperMinterV1_1SymTest is SuperMinterV1_1 {
+
+    /// @custom:halmos --no-test-constructor --symbolic-storage
+    function check_totalPriceAndFees(
+        uint8 tier,
+        uint256 mintId,
+        uint32 quantity,
+        uint96 signedPrice
+    ) public {
+        MintData storage d = _getMintData(mintId);
+        _totalPriceAndFees(tier, d, quantity, signedPrice);
+    }
+
+}


### PR DESCRIPTION
Preliminary halmos tests for formal verification of fee computation.

To run the halmos tests, update submodules, [install halmos](https://github.com/a16z/halmos), and run:
```
halmos
```